### PR TITLE
Add `README` and `linux-containerfile`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# Ayon USD
+
+This repo is a collection of tools that allows you to build [USD](https://github.com/PixarAnimationStudios/OpenUSD) via Docker (or Podman) in a safe environment and with your choice of Python version so you can get the binaries as fast as possible (hardware dependant) and avoidinmg to "pollute" your system.
+
+It's based on the [Azure pipelines that Pixar](https://github.com/PixarAnimationStudios/OpenUSD/blob/release/azure-pipelines.yml) uses to run their automated builds, with some added QoL, such as being able to define a Python version.
+
+## How to use
+
+### Linux
+
+It builds USD with the following arguments: `--ptex --openvdb --openimageio --openimageio --alembic --hdf5`
+
+Clone this repository in your computer and then simply run within:
+  `podman build -t usd-linux:py37 -f linux-containerfile --build-arg PYTHON_VERSION="3.7"`
+
+If not `PYTHON_VERSION` build arg is specified, it defaults to `3.9` (as per the VFX Platfrom Reference):
+  `podman build -t usd-linux -f linux-containerfile`
+
+This will take a while, so grab a cup of your favourite beverage, if all goes well, you should have an image with `USD` built at the `/USD` folder, you can now extract the contents by starting a container with said image, and then copying the contents:
+```
+  # First spawn a container with the `usd-linux` image
+  podman run -it --rm  usd-linux bash 
+```
+
+On **another** terminal:
+  ```
+  # List all the runnign containers
+  podman ps | grep usd-linux
+  # Note down the ${container-id} from the command above
+  podman cp ${container-id}:/USD /path/in/your/host/USD
+```
+
+You should now have USD binaries in `/path/in/your/host/USD`, note that if you are going to use any of the tools that require Python bindings you'll have to match the Python version used at build time!
+
+## Todo
+ - [] Windows Dockerfile.
+ - [] MacOs Dockerfile.
+ - [] Allow passing USD build arguments.
+
+

--- a/linux-containerfile
+++ b/linux-containerfile
@@ -1,0 +1,37 @@
+FROM ubuntu:focal
+ARG PYTHON_VERSION=3.9
+ENV PYTHONBUFFERED=1
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=Europe/London
+
+RUN mkdir /USD
+RUN mkdir /src
+WORKDIR /src
+
+# Add RTX repo - Easier to install/build diffenrent Pytohn versions.
+RUN apt-get update && apt-get install --assume-yes gpg wget 
+RUN wget -qO - https://rtx.pub/gpg-key.pub | gpg --dearmor | tee /usr/share/keyrings/rtx-archive-keyring.gpg 1> /dev/null
+RUN echo "deb [signed-by=/usr/share/keyrings/rtx-archive-keyring.gpg arch=amd64] https://rtx.pub/deb stable main" | tee /etc/apt/sources.list.d/rtx.list
+
+# Install RTX and Python Building deps
+RUN apt-get update && apt-get install --assume-yes rtx git zlib1g-dev libssl-dev libffi-dev libbz2-dev libncurses-dev libncursesw5-dev libgdbm-dev liblzma-dev libsqlite3-dev tk-dev libgdbm-compat-dev libreadline-dev
+RUN rtx install python@$PYTHON_VERSION
+RUN rtx use -g python@$PYTHON_VERSION
+# Symlink all the `rtx` binaries
+RUN ln -s $(dirname `rtx which python`)/* /usr/bin/
+
+# Ensurepip and install Python deps for USD building
+RUN python -m ensurepip
+RUN python -m pip install --upgrade pip
+RUN python -m pip install PySide2 PyOpenGL
+
+# Symlink again, to get PySide's tools
+RUN ln -sf $(dirname `rtx which python`)/* /usr/bin/
+RUN ls -lha /usr/bin | grep rtx
+
+# Install USD Building deps and build it
+RUN apt-get install --assume-yes cmake pkg-config libglew-dev libxrandr-dev libxcursor-dev libxinerama-dev libxi-dev libxt-dev
+RUN git clone https://github.com/PixarAnimationStudios/OpenUSD.git --branch release . 
+RUN python -m pip show PySide2
+RUN python build_scripts/build_usd.py /USD --ptex --openvdb --openimageio --openimageio --alembic --hdf5 -v
+


### PR DESCRIPTION
Allows the person to build USD on Linux, based on Ubuntu, with the desired Python version.