### PR TITLE
Bug: add version number

### DIFF
--- a/client/ayon_usd/addon.py
+++ b/client/ayon_usd/addon.py
@@ -3,6 +3,7 @@ import os
 
 from ayon_core.modules import AYONAddon, ITrayModule
 from .utils import is_usd_download_needed, get_downloaded_usd_root
+from .version import __version__
 
 USD_ADDON_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -17,6 +18,7 @@ class USDAddon(AYONAddon, ITrayModule):
     """
 
     name = "ayon_usd"
+    version = __version__
     _download_window = None
 
     def tray_init(self):

--- a/client/ayon_usd/version.py
+++ b/client/ayon_usd/version.py
@@ -7,4 +7,4 @@ build system based on the content of package.py.
 Do not manually edit this file.
 """
 name = "ayon_usd"
-__version__ = "1.0.2"
+__version__ = "1.0.3-dev.1"

--- a/create_package.py
+++ b/create_package.py
@@ -383,7 +383,9 @@ def main(
         keep_sources (bool): Keep sources when server package is created.
 
     """
-    log = logging.getLogger("create_package")
+    logging.basicConfig(level=logging.INFO)
+    log = logging.getLogger("create_package", level=logging.INFO)
+
     log.info("Start creating package")
 
     current_dir = os.path.dirname(os.path.abspath(__file__))

--- a/package.py
+++ b/package.py
@@ -1,7 +1,7 @@
 """AYON USD Addon package file."""
 name = "ayon_usd"
-title = "AYON Addon providing USD support"
-version = "1.0.2"
+title = "AYON USD support"
+version = "1.0.3-dev.1"
 client_dir = "ayon_usd"
 
 services = {}


### PR DESCRIPTION
## Changes

Addon was missing version number resulting in `DEV WARNING: Addon 'ayon_usd' does not have defined version.` during the launch. It is also setting log level in `create_package.py` so some progress is seen as working with USD binaries can time some time.