### PR TITLE
Stop redownloading USD every time

### DIFF
--- a/client/ayon_usd/addon.py
+++ b/client/ayon_usd/addon.py
@@ -2,7 +2,7 @@
 import os
 
 from ayon_core.modules import AYONAddon, ITrayModule
-from .utils import is_usd_download_needed, get_downloaded_usd_root
+from .utils import is_usd_download_needed
 from .version import __version__
 
 USD_ADDON_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/client/ayon_usd/addon.py
+++ b/client/ayon_usd/addon.py
@@ -38,7 +38,6 @@ class USDAddon(AYONAddon, ITrayModule):
         super(USDAddon, self).tray_start()
         download_usd = is_usd_download_needed()
         if not download_usd:
-            print(f"get_downloaded_usd_root: {get_downloaded_usd_root()}")
             return
 
         from .download_ui import show_download_window

--- a/client/ayon_usd/utils.py
+++ b/client/ayon_usd/utils.py
@@ -176,7 +176,8 @@ def get_downloaded_usd_root() -> Union[str, None]:
     if _USDOptions.downloaded_root is not NOT_SET:
         return _USDOptions.downloaded_root
 
-    server_usd_info = _find_file_info("usd", get_server_files_info())
+    server_usd_info = _find_file_info(
+        "ayon_usd", get_server_files_info())
     if not server_usd_info:
         return None
 


### PR DESCRIPTION
## Changes

There was a bug that caused addon to re-download the USD binaries everytime from the server. This is fixing it.