### PR TITLE
fixed build pipline. error: logger log lvl set in an outdated way

### DIFF
--- a/create_package.py
+++ b/create_package.py
@@ -384,7 +384,8 @@ def main(
 
     """
     logging.basicConfig(level=logging.INFO)
-    log = logging.getLogger("create_package", level=logging.INFO)
+    log = logging.getLogger("create_package")
+    log.setLevel(logging.INFO)
 
     log.info("Start creating package")
 

--- a/tools/manage.sh
+++ b/tools/manage.sh
@@ -178,7 +178,7 @@ run_codespell () {
 
 build () {
   echo -e "${BIGreen}>>>${RST} Building the addon ..."
-  python ./create_package.py -v
+  python ./create_package.py
 
 }
 


### PR DESCRIPTION
The development branch has two bugs in the `create_package.py` and `manage.sh` respectively. 

`manage.sh` is calling `create_package.py` with the `-v` flag; this option is no longer available and can be removed. 
`create_package.py` tries to create the logger instance with the log level parameter, but that needs to be done via setLevel()