### PR TITLE
removed GRPs from the app groups in the PreLaunchHook to avoid trying…

### DIFF
--- a/client/ayon_usd/hooks/pre_resolver_init.py
+++ b/client/ayon_usd/hooks/pre_resolver_init.py
@@ -13,7 +13,7 @@ class InitializeAssetResolver(PreLaunchHook):
     Asset resolver is used to resolve assets in the application.
     """
 
-    app_groups = {"maya", "nuke", "nukestudio", "houdini", "blender", "unreal"}
+    app_groups = {"maya", "houdini", "unreal"}
     launch_types = {LaunchTypes.local}
 
     def _setup_resolver(self, local_resolver, settings):


### PR DESCRIPTION
… to setup a resolver for an app we dont yet suport.

## Changelog Description
this PR Removes the Prelaunch Trigger's for software packages that we dont have Resolvers for. 


## Additional info



## Testing notes:

1. Clone the Repo Switch to the Branch create a Package upload to server. 
2. open one of the suported apps and load an Ayon Uri (you can get this by selecting a represenation for a Published Product (needs to be USD) and then copy the Ayon:// uri)
3. now open an app not in the list and see if it starts
