### PR TITLE
added a popup for the warning and make the addon start without qt

### DIFF
--- a/client/ayon_usd/__init__.py
+++ b/client/ayon_usd/__init__.py
@@ -4,7 +4,7 @@
 # TODO ayon_api has a check for headless mode. we need to see if that system covers all fronts 
 HEADLESS_MODE = True 
 try:
-    import qtpy
+    import qtpy # noqa: F401
     HEADLESS_MODE = False
 except ImportError:
     print("qt.py or a Qt binding is not installed.")

--- a/client/ayon_usd/__init__.py
+++ b/client/ayon_usd/__init__.py
@@ -1,5 +1,5 @@
 """USD Addon for AYON - client part."""
-
+# flake8: noqa F401
 
 # TODO ayon_api has a check for headless mode. we need to see if that system covers all fronts 
 HEADLESS_MODE = True 
@@ -10,8 +10,6 @@ except ImportError:
     print("qt.py or a Qt binding is not installed.")
 except Exception as e: 
     raise RuntimeError(f"An error occurred while checking for Qt: {e}")
-
-
 
 from .addon import USDAddon
 from .utils import (

--- a/client/ayon_usd/__init__.py
+++ b/client/ayon_usd/__init__.py
@@ -1,5 +1,18 @@
 """USD Addon for AYON - client part."""
 
+
+# TODO ayon_api has a check for headless mode. we need to see if that system covers all fronts 
+HEADLESS_MODE = True 
+try:
+    import qtpy
+    HEADLESS_MODE = False
+except ImportError:
+    print("qt.py or a Qt binding is not installed.")
+except Exception as e: 
+    raise RuntimeError(f"An error occurred while checking for Qt: {e}")
+
+
+
 from .addon import USDAddon
 from .utils import (
     get_download_dir

--- a/client/ayon_usd/addon.py
+++ b/client/ayon_usd/addon.py
@@ -9,11 +9,15 @@ from ayon_core.addon import AYONAddon, ITrayAddon
 from ayon_core import style
 from ayon_core.settings import get_studio_settings
 
+from ayon_usd import HEADLESS_MODE
+
 from . import config, utils
 from .utils import ADDON_DATA_JSON_PATH, DOWNLOAD_DIR, USD_ADDON_ROOT_DIR
 from .version import __version__
 
-from .ayon_bin_client.ayon_bin_distro.gui import progress_ui
+
+if not HEADLESS_MODE:
+    from .ayon_bin_client.ayon_bin_distro.gui import progress_ui
 from .ayon_bin_client.ayon_bin_distro.work_handler import worker
 from .ayon_bin_client.ayon_bin_distro.util import zip
 
@@ -38,6 +42,12 @@ class USDAddon(AYONAddon, ITrayAddon):
     def initialize(self, module_settings):
         """Initialize USD Addon."""
         if not module_settings["ayon_usd"]["allow_addon_start"]:
+            if not HEADLESS_MODE:
+                utils.info_popup("Ayon Usd Addon", "The experimental AyonUsd addon is currently activated, "
+                "but you haven't yet acknowledged the user agreement "
+                "indicating your understanding that this feature is "
+                "experimental. Please go to the Studio Settings and "
+                "check the agreement checkbox.")
             raise SystemError(
                 "The experimental AyonUsd addon is currently activated, "
                 "but you haven't yet acknowledged the user agreement "
@@ -120,17 +130,20 @@ class USDAddon(AYONAddon, ITrayAddon):
             progress_title="Unzip UsdLib",
             dependency_id=[usd_download_work_item.get_uuid()],
         )
-
-        download_ui = progress_ui.ProgressDialog(
-            controller,
-            close_on_finish=True,
-            auto_close_timeout=1,
-            delet_progress_bar_on_finish=False,
-            title="ayon_usd-Addon [UsdLib Download]",
-        )
-        download_ui.setStyleSheet(style.load_stylesheet())
-        download_ui.start()
-        self._download_window = download_ui
+        
+        if not HEADLESS_MODE:
+            download_ui = progress_ui.ProgressDialog(
+                controller,
+                close_on_finish=True,
+                auto_close_timeout=1,
+                delet_progress_bar_on_finish=False,
+                title="ayon_usd-Addon [UsdLib Download]",
+            )
+            download_ui.setStyleSheet(style.load_stylesheet())
+            download_ui.start()
+            self._download_window = download_ui
+        else:
+            controller.start()
 
     def tray_exit(self):
         """Exit tray module."""

--- a/client/ayon_usd/utils.py
+++ b/client/ayon_usd/utils.py
@@ -8,11 +8,26 @@ import sys
 
 from ayon_usd.ayon_bin_client.ayon_bin_distro.work_handler import worker
 from ayon_usd.ayon_bin_client.ayon_bin_distro.util import zip
-from ayon_usd import config
+from ayon_usd import config, HEADLESS_MODE
+
+if not HEADLESS_MODE:
+    from qtpy import QtCore, QtGui, QtWidgets
 
 USD_ADDON_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 DOWNLOAD_DIR = os.path.join(USD_ADDON_ROOT_DIR, "downloads")
 ADDON_DATA_JSON_PATH = os.path.join(DOWNLOAD_DIR, "ayon_usd_addon_info.json")
+
+def info_popup(title:str, message:str):
+    app = QtWidgets.QApplication() 
+    msg = QtWidgets.QMessageBox() 
+    msg.setWindowTitle(title) 
+    msg.setText(message) 
+    msg.setIcon(QtWidgets.QMessageBox.Information) 
+    
+    msg.setStandardButtons(QtWidgets.QMessageBox.Ok)
+    msg.setDefaultButton(QtWidgets.QMessageBox.Ok) 
+    
+    response = msg.exec_()
 
 
 def get_download_dir(create_if_missing=True):

--- a/client/ayon_usd/utils.py
+++ b/client/ayon_usd/utils.py
@@ -11,14 +11,13 @@ from ayon_usd.ayon_bin_client.ayon_bin_distro.util import zip
 from ayon_usd import config, HEADLESS_MODE
 
 if not HEADLESS_MODE:
-    from qtpy import QtCore, QtGui, QtWidgets
+    from qtpy import QtWidgets
 
 USD_ADDON_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 DOWNLOAD_DIR = os.path.join(USD_ADDON_ROOT_DIR, "downloads")
 ADDON_DATA_JSON_PATH = os.path.join(DOWNLOAD_DIR, "ayon_usd_addon_info.json")
 
 def info_popup(title:str, message:str):
-    app = QtWidgets.QApplication() 
     msg = QtWidgets.QMessageBox() 
     msg.setWindowTitle(title) 
     msg.setText(message) 
@@ -26,9 +25,6 @@ def info_popup(title:str, message:str):
     
     msg.setStandardButtons(QtWidgets.QMessageBox.Ok)
     msg.setDefaultButton(QtWidgets.QMessageBox.Ok) 
-    
-    response = msg.exec_()
-
 
 def get_download_dir(create_if_missing=True):
     """Dir path where files are downloaded.


### PR DESCRIPTION
## Changelog Description
this adds a HEADLESS MODE test and a TODO to improve the HEADLESS_MODE test as its currently very basic. 
it also adds a QT popup to warn about not enabled plugin. 



## Additional info



## Testing notes:

1. upload addon
2. dont activate / agree to the experimental tings 
3. start the launcher and see a popup 
