### PR TITLE
changed lake ctl wrapper to v0.1.1 because we changed the name of the…

### DIFF
--- a/client/ayon_usd/version.py
+++ b/client/ayon_usd/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring AYON addon 'ayon_usd' version."""
-__version__ = "0.1.0-alpha"
+__version__ = "0.1.0-alpha-dev.1"

--- a/package.py
+++ b/package.py
@@ -2,7 +2,7 @@
 
 name = "ayon_usd"
 title = "Usd Addon"
-version = "0.1.0-alpha"
+version = "0.1.0-alpha-dev.1"
 client_dir = "ayon_usd"
 
 services = {}


### PR DESCRIPTION
… lake config file to be written into the zips by create package

## Changelog Description
this PR changes the bin bridge client version to v0.1.1 because this version renames the lake config file and removes the `.` from the config file. 
with this, the create_package.py now packages this file into the zip. 


## Additional info



## Testing notes:

1. create a package 
2. unzip the create package zip and look into the client/bin_bridge_distro/lakectlpy/bin foulder and check if the dummy_lake_conf.yaml is there
