### PR TITLE
Fix execution condition and anatomy

### DIFF
--- a/client/ayon_usd/hooks/usd_pinning_root.py
+++ b/client/ayon_usd/hooks/usd_pinning_root.py
@@ -1,23 +1,26 @@
 """Pre-launch hook to set USD pinning related environment variable."""
-from typing import ClassVar
-
+from ayon_api import get_folder_by_path, get_project, get_task_by_name
 from ayon_applications import LaunchTypes, PreLaunchHook
+from ayon_core.pipeline import Anatomy
 
 
 class UsdPinningRoot(PreLaunchHook):
     """Pre-launch hook to set USD_ROOT environment variable."""
 
-    app_groups: ClassVar = {"maya", "houdini", "blender", "unreal"}
+    app_groups = {"maya", "houdini", "blender", "unreal"}
     # this should be set to farm_render, but this issue
     # https://github.com/ynput/ayon-applications/issues/2
     # stands in the way
-    launch_types: ClassVar = {LaunchTypes.farm_publish}
+    launch_types = {LaunchTypes.farm_publish}
 
     def execute(self) -> None:
         """Set environments necessary for pinning."""
-        if self.launch_context.env.get("PINNING_FILE_PATH"):
+        if not self.launch_context.env.get("PINNING_FILE_PATH"):
             return
-        anatomy = self.launch_context.anatomy
+
+        project_entity = get_project(self.data.project_name)
+        anatomy = Anatomy(
+            self.data.project_name, project_entity=project_entity)
         self.launch_context.env["PINNING_FILE_PATH"] = anatomy.fill_root(
             self.launch_context.env.get("PINNING_FILE_PATH"),
         )

--- a/client/ayon_usd/hooks/usd_pinning_root.py
+++ b/client/ayon_usd/hooks/usd_pinning_root.py
@@ -1,7 +1,5 @@
 """Pre-launch hook to set USD pinning related environment variable."""
-from ayon_api import get_project
 from ayon_applications import LaunchTypes, PreLaunchHook
-from ayon_core.pipeline import Anatomy
 
 
 class UsdPinningRoot(PreLaunchHook):

--- a/client/ayon_usd/hooks/usd_pinning_root.py
+++ b/client/ayon_usd/hooks/usd_pinning_root.py
@@ -18,9 +18,7 @@ class UsdPinningRoot(PreLaunchHook):
         if not self.launch_context.env.get("PINNING_FILE_PATH"):
             return
 
-        project_entity = get_project(self.data.project_name)
-        anatomy = Anatomy(
-            self.data.project_name, project_entity=project_entity)
+        anatomy = self.data["anatomy"]
         self.launch_context.env["PINNING_FILE_PATH"] = anatomy.fill_root(
             self.launch_context.env.get("PINNING_FILE_PATH"),
         )

--- a/client/ayon_usd/hooks/usd_pinning_root.py
+++ b/client/ayon_usd/hooks/usd_pinning_root.py
@@ -1,5 +1,5 @@
 """Pre-launch hook to set USD pinning related environment variable."""
-from ayon_api import get_folder_by_path, get_project, get_task_by_name
+from ayon_api import get_project
 from ayon_applications import LaunchTypes, PreLaunchHook
 from ayon_core.pipeline import Anatomy
 


### PR DESCRIPTION
## Changelog Description
Anatomy isn't available on launch context so it needs to be specifically created. Also there was a bug about the condition when this hook should be executed - it should only when there are pinning environments present on the job.

## Testing notes:

Publish USD render job on farm - pinning should work if enabled.
Publish non-USD related job on farm - usd prelaunch hook should not be involved.
