### PR TITLE
Chore: Change addon name to 'usd'

### DIFF
--- a/Docs/Ayon_Docs/Admin_Docs.md
+++ b/Docs/Ayon_Docs/Admin_Docs.md
@@ -5,8 +5,8 @@
 > LakeFs keys (LakeFs is the data server we use to distribute Bin data) you can
 > get those Keys on our Discord server just ask one of the Ynput staff for them.
 > the settings are the following:
-> `ayon+settings://ayon_usd/lakefs/access_key_id` and
-> `ayon+settings://ayon_usd/lakefs/secret_access_key`
+> `ayon+settings://usd/lakefs/access_key_id` and
+> `ayon+settings://usd/lakefs/secret_access_key`
 
 USD is a modern, open-source, scene description and file format developed by
 Pixar Animation Studios. It's an Extensive and extendable C++Lib that is used 
@@ -44,28 +44,28 @@ need to touch them though.
 
 **LakeFs Settings:**
 
-The `ayon+settings://ayon_usd/lakefs` section configures the backend
+The `ayon+settings://usd/lakefs` section configures the backend
 for our bin distribution system, which uses the specified server to download
 resolvers and AyonUsdLibs from LakeFs.
 
 
 **LakeFs Server Uri:**
 
-`ayon+settings://ayon_usd/lakefs/server_repo`
+`ayon+settings://usd/lakefs/server_repo`
 
 This is the URI used to host the LakeFs server.  You can find the Ynput server at
 `https://lake.ayon.cloud`
 
 **LakeFs Repository URI:**
 
-`ayon+settings://ayon_usd/lakefs/server_repo`
+`ayon+settings://usd/lakefs/server_repo`
 
 This is a LakeFs internal link that specifies the branch you are downloading
 from. This can be useful if you want to pin your pipeline to a specific release.
 
 **Asset Resolvers:**
 
-`ayon+settings://ayon_usd/lakefs/asset_resolvers`
+`ayon+settings://usd/lakefs/asset_resolvers`
 
 This allows you to associate a specific Application name with a specific
 resolver. We always set up all the resolvers we compile, but if you have special
@@ -75,32 +75,32 @@ as an alias for the Hou19.5 entry because they share the same resolver.
 
 #### Usd Resolver Config
 
-`ayon+settings://ayon_usd/ayon_usd_resolver`
+`ayon+settings://usd/ayon_usd_resolver`
 
-**Log Lvl** `ayon+settings://ayon_usd/ayon_usd_resolver/ayon_log_lvl`
+**Log Lvl** `ayon+settings://usd/ayon_usd_resolver/ayon_log_lvl`
 control the log lvl of the AyonUsdResolver. It is advised to have this at Warn
 or Critical as Logging will impact the performance.
 
 **File Logger Enabled**
-`ayon+settings://ayon_usd/ayon_usd_resolver/ayon_file_logger_enabled`
+`ayon+settings://usd/ayon_usd_resolver/ayon_file_logger_enabled`
 AyonUsdResolver includes a file logger if needed.
 
 **Logging Keys**
-`ayon+settings://ayon_usd/ayon_usd_resolver/ayon_logger_logging_keys`
+`ayon+settings://usd/ayon_usd_resolver/ayon_logger_logging_keys`
 AyonUsdResolver Logger has a few predefined logging keys that can be enabled for
 Debugging. it is advised to only do this with Developer bundles as it can expose
 AYON Server data. it will also generate quite a big output.
 
 **File Logger Path**
-`ayon+settings://ayon_usd/ayon_usd_resolver/file_logger_file_path` The
+`ayon+settings://usd/ayon_usd_resolver/file_logger_file_path` The
 Ayon File Logger needs an output path this needs to be a relative or absolute
 path to a folder.
 
 #### UsdLib Config:
 
-`ayon+settings://ayon_usd/usd`
+`ayon+settings://usd/usd`
 
-**Tf_Debug** `ayon+settings://ayon_usd/usd/usd_tf_debug`\
+**Tf_Debug** `ayon+settings://usd/usd/usd_tf_debug`\
 this allows you to set the UsdTfDebug env variable to get extra debug info from
 the UsdLib.\
 [Usd Survival Guide (Luca Sheller)](https://lucascheller.github.io/VFX-UsdSurvivalGuide/core/profiling/debug.html)\

--- a/README.md
+++ b/README.md
@@ -25,6 +25,6 @@ You can find Admin and Developer docs under Docs/Ayon_Docs/
 3. Run `.\tools\manage.ps1 build` on Windows or `./tools/manage.sh build` on
    Linux.
 4. In AYON, go to `Studio Settings` -> `Bundles` -> `Install Addons...` and
-   select the `./package/ayon_usd-x.x.x.zip` file.
+   select the `./package/usd-x.x.x.zip` file.
 5. Upload the Addon and let the server restart after installation is done.
 6. Use new addon in your bundles.

--- a/client/ayon_usd/addon.py
+++ b/client/ayon_usd/addon.py
@@ -28,7 +28,7 @@ class USDAddon(AYONAddon, ITrayAddon, IPluginPaths):
     Cares about supplying USD Framework.
     """
 
-    name = "ayon_usd"
+    name = "usd"
     version = __version__
     _download_window = None
 
@@ -36,9 +36,9 @@ class USDAddon(AYONAddon, ITrayAddon, IPluginPaths):
         """Initialize tray module."""
         super(USDAddon, self).tray_init()
 
-    def initialize(self, module_settings):
+    def initialize(self, studio_settings):
         """Initialize USD Addon."""
-        if not module_settings["ayon_usd"]["allow_addon_start"]:
+        if not studio_settings["usd"]["allow_addon_start"]:
             raise SystemError(
                 "The experimental AyonUsd addon is currently activated, "
                 "but you haven't yet acknowledged the user agreement "

--- a/client/ayon_usd/config.py
+++ b/client/ayon_usd/config.py
@@ -28,7 +28,7 @@ def get_global_lake_instance(settings=None):
 
     if not settings:
         settings = get_studio_settings()
-    lakefs = settings["ayon_usd"]["lakefs"]
+    lakefs = settings["usd"]["lakefs"]
     return wrapper.LakeCtl(
         server_url=lakefs["server_uri"],
         access_key_id=lakefs["access_key_id"],
@@ -59,6 +59,6 @@ def get_lakefs_usdlib_name(lake_fs_repo: str) -> str:
 
 def get_lakefs_usdlib_path(settings: dict) -> str:
     """Return AyonUsdBin/usd LakeFS full url for current platform. """
-    lake_fs_repo = settings["ayon_usd"]["lakefs"]["server_repo"]
+    lake_fs_repo = settings["usd"]["lakefs"]["server_repo"]
     usd_lib_conf = get_lakefs_usdlib_name(lake_fs_repo)
     return f"{lake_fs_repo}{usd_lib_conf}"

--- a/client/ayon_usd/utils.py
+++ b/client/ayon_usd/utils.py
@@ -51,7 +51,7 @@ def is_usd_lib_download_needed(settings: dict) -> bool:
         bool: When true, a new download is required.
 
     """
-    lake_fs_repo = settings["ayon_usd"]["lakefs"]["server_repo"]
+    lake_fs_repo = settings["usd"]["lakefs"]["server_repo"]
     usd_lib_dir = os.path.abspath(get_downloaded_usd_root(lake_fs_repo))
     if not os.path.exists(usd_lib_dir):
         return True
@@ -119,7 +119,7 @@ def get_resolver_to_download(settings, app_name: str) -> str:
     Returns: str: LakeFs object path to be used with lake_fs_py wrapper
 
     """
-    lakefs = settings["ayon_usd"]["lakefs"]
+    lakefs = settings["usd"]["lakefs"]
     resolver_overwrite_list = lakefs["lake_fs_overrides"]
     if resolver_overwrite_list:
         resolver_overwrite = next(
@@ -206,9 +206,9 @@ def get_resolver_setup_info(
         env, "PYTHONPATH", resolver_python_path.as_posix()
     )
 
-    resolver_settings = settings["ayon_usd"]["ayon_usd_resolver"]
+    resolver_settings = settings["usd"]["ayon_usd_resolver"]
     return {
-        "TF_DEBUG": settings["ayon_usd"]["usd"]["usd_tf_debug"],
+        "TF_DEBUG": settings["usd"]["usd"]["usd_tf_debug"],
         "AYONLOGGERLOGLVL": resolver_settings["ayon_log_lvl"],
         "AYONLOGGERSFILELOGGING": resolver_settings["ayon_file_logger_enabled"],  # noqa
         "AYONLOGGERSFILEPOS": resolver_settings["file_logger_file_path"],

--- a/client/ayon_usd/version.py
+++ b/client/ayon_usd/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
-"""Package declaring AYON addon 'ayon_usd' version."""
+"""Package declaring AYON addon 'usd' version."""
 __version__ = "0.1.0"

--- a/package.py
+++ b/package.py
@@ -1,7 +1,7 @@
 """AYON USD Addon package file."""
 
-name = "ayon_usd"
-title = "Usd Addon"
+name = "usd"
+title = "USD"
 version = "0.1.0"
 client_dir = "ayon_usd"
 

--- a/tests/client/ayon_usd/conftest.py
+++ b/tests/client/ayon_usd/conftest.py
@@ -244,12 +244,12 @@ def installed_addon(
     response = session.post(
         f"{server_url}/api/addons/install",
         json={
-            "addonName": "ayon_usd",
+            "addonName": "usd",
             "addonVersion": version
         },
         files={
             "upload_file": open(
-                build_addon_package[1] / f"ayon_usd-{version}.zip", "rb")
+                build_addon_package[1] / f"usd-{version}.zip", "rb")
         }
     )
     assert response.status_code == 200, f"Failed to install addon: {response.text}"
@@ -269,12 +269,12 @@ def installed_addon(
     assert response.status_code == 200, f"Failed to get installed addons: {response.text}"
 
     addon_names = [item["addonName"] for item in response.json()["items"]]
-    assert "ayon_usd" in addon_names, f"Addon 'ayon_usd' not found in installed addons: {addon_names}"
+    assert "usd" in addon_names, f"Addon 'usd' not found in installed addons: {addon_names}"
 
     yield version
 
     printer_session("Uninstalling addon ...")
-    # response = session.delete(f"{server_url}/api/ayon_usd/{version}")
+    # response = session.delete(f"{server_url}/api/usd/{version}")
     # assert response.status_code == 200, f"Failed to uninstall addon: {response.text}"
 
     

--- a/tests/client/ayon_usd/test_utils.py
+++ b/tests/client/ayon_usd/test_utils.py
@@ -38,5 +38,5 @@ def test_file_info_endpoint(
     session = ayon_server_session
     version = installed_addon
 
-    response = session.get(f"{server_url}/api/addons/ayon_usd/{version}/files_info")
+    response = session.get(f"{server_url}/api/addons/usd/{version}/files_info")
     assert response.status_code == 200


### PR DESCRIPTION
## Changelog Description
Renamed addon from `ayon_usd` to `usd`.

## Testing notes:
1. Validate that all places that were dependent on `ayon_usd` addon name are correct now.
