### PR TITLE
Do not 'crash' AYON launch or application launch because of lack of USD resolver

### DIFF
--- a/client/ayon_usd/addon.py
+++ b/client/ayon_usd/addon.py
@@ -39,14 +39,15 @@ class USDAddon(AYONAddon, ITrayAddon, IPluginPaths):
     def initialize(self, studio_settings):
         """Initialize USD Addon."""
         if not studio_settings["usd"]["allow_addon_start"]:
-            raise SystemError(
-                "The experimental AyonUsd addon is currently activated, "
+            self.log.error(
+                "The experimental AYON USD addon is currently activated, "
                 "but you haven't yet acknowledged the user agreement "
                 "indicating your understanding that this feature is "
                 "experimental. Please go to the Studio Settings and "
-                "check the agreement checkbox."
+                "check the agreement checkbox. The AYON USD addon will now "
+                "be disabled"
             )
-        self.enabled = True
+            self.enabled = False
         self._download_window = None
 
     def tray_start(self):

--- a/client/ayon_usd/hooks/pre_resolver_init.py
+++ b/client/ayon_usd/hooks/pre_resolver_init.py
@@ -32,12 +32,13 @@ class InitializeAssetResolver(PreLaunchHook):
         resolver_lake_fs_path = utils.get_resolver_to_download(
             project_settings, self.app_name)
         if not resolver_lake_fs_path:
-            raise RuntimeError(
-                "No USD Resolver could be found but "
-                f"AYON-Usd addon is activated {self.app_name}"
+            self.log.warning(
+                "No USD Resolver could be found but AYON-Usd addon is"
+                f" activated for application: {self.app_name}"
             )
+            return
 
-        self.log.info(f"Using resolver from LakeFS: {resolver_lake_fs_path}")
+        self.log.info(f"Using resolver from lakeFS: {resolver_lake_fs_path}")
         lake_fs = config.get_global_lake_instance()
         lake_fs_resolver_time_stamp = (
             lake_fs.get_element_info(resolver_lake_fs_path).get(
@@ -45,10 +46,11 @@ class InitializeAssetResolver(PreLaunchHook):
             )
         )
         if not lake_fs_resolver_time_stamp:
-            raise ValueError(
-                "Could not find resolver timestamp on LakeFs server "
+            self.log.error(
+                "Could not find resolver timestamp on lakeFS server "
                 f"for application: {self.app_name}"
             )
+            return
 
         # Check for existing local resolver that matches the lakefs timestamp
         with open(ADDON_DATA_JSON_PATH, "r") as data_json:


### PR DESCRIPTION
## Changelog Description

This replaces hard errors on AYON launch or application launch if the "Experimental" checkbox is not checked or a USD resolver is not found for a particular application version that you're trying to launch.

## Additional info

## Testing notes:

1. Launch AYON with experimental checkbox disabled. It should allow launching as usual but disable the USD addon.

![image](https://github.com/user-attachments/assets/4d34a4bb-e234-4ee4-8ca8-ce5590ea6812)

Note that the log appears many times when launching an application - it seems `AddonsManager` get initialized many many times?
![image](https://github.com/user-attachments/assets/d2ba91fb-49e4-4bf2-b238-d014a304db96)

2. Launch AYON with experimental checkbox enabled, but do not configure LakeFS should 'error' in the logs on AYON start and log a warning on application launch.

![image](https://github.com/user-attachments/assets/b8bffe34-ec9c-4551-901b-fc9b983643c8)

3. When lakeFS server and keys are configured - it should launch fine for supported application that has a resolver:

![image](https://github.com/user-attachments/assets/ac48f212-861f-4fed-9664-f69fcc59ee3a)

4. And should launch fine for supported application variant that does not yet have a resolver (but log a warning):

![image](https://github.com/user-attachments/assets/928535ad-fa6d-4bd4-9a29-f5dbbfb5facf)
