### PR TITLE
Integrate Pinning file: Do not error on bad escape in regex pattern

### DIFF
--- a/client/ayon_usd/standalone/usd/pinning/_pinning_file_generation_funcs.py
+++ b/client/ayon_usd/standalone/usd/pinning/_pinning_file_generation_funcs.py
@@ -50,8 +50,7 @@ def remove_root_from_dependency_info(
         )
 
     replacements = {path: replacer for replacer, path in root_info.items()}
-
-    pattern = "|".join(f"({pat})" for pat in replacements)
+    pattern = "|".join(f"({re.escape(pat)})" for pat in replacements)
     regx = re.compile(pattern)
 
     # TODO test if there are cases where we have more than one match.group


### PR DESCRIPTION
## Changelog Description

Do not error on bad escape in regex pattern

## Additional info

Fixes #63 

## Testing notes:

1. Configure project roots: XXX (to be defined!)
2. Run a simple Maya USD publish from Maya (e.g. publish a cube)
