### PR TITLE
Make LakeFS distribution of USD Libs and AYON USD Resolver optional

### DIFF
--- a/client/ayon_usd/hooks/pre_resolver_init.py
+++ b/client/ayon_usd/hooks/pre_resolver_init.py
@@ -16,19 +16,15 @@ class InitializeAssetResolver(PreLaunchHook):
     app_groups = {"maya", "houdini", "unreal"}
     launch_types = {LaunchTypes.local}
 
-    def _setup_resolver(self, local_resolver, settings):
-        self.log.info(
-            f"Initializing USD asset resolver for application: {self.app_name}"
-        )
-
-        updated_env = utils.get_resolver_setup_info(
-            local_resolver, settings, env=self.launch_context.env
-        )
-        self.launch_context.env.update(updated_env)
-
     def execute(self):
         """Pre-launch hook entry method."""
         project_settings = self.data["project_settings"]
+        if not project_settings["usd"]["lakefs"].get("enabled", False):
+            self.log.info(
+                "USD LakeFS binary distribution for AYON USD Resolver is"
+                " disabled.")
+            return
+
         resolver_lake_fs_path = utils.get_resolver_to_download(
             project_settings, self.app_name)
         if not resolver_lake_fs_path:
@@ -85,3 +81,13 @@ class InitializeAssetResolver(PreLaunchHook):
             json.dump(addon_data_json, addon_json)
 
         self._setup_resolver(local_resolver, project_settings)
+
+    def _setup_resolver(self, local_resolver, settings):
+        self.log.info(
+            f"Initializing USD asset resolver for application: {self.app_name}"
+        )
+
+        updated_env = utils.get_resolver_setup_info(
+            local_resolver, settings, env=self.launch_context.env
+        )
+        self.launch_context.env.update(updated_env)

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -98,9 +98,11 @@ class AppPlatformURIModel(BaseSettingsModel):
 
 
 class LakeFsSettings(BaseSettingsModel):
-    """LakeFs Settings / Download Settings ?"""
+    """LakeFS binary distribution of USD and AYON USD Resolver"""
 
     _layout = "collapsed"
+
+    enabled: bool = SettingsField(False)
 
     server_uri: str = SettingsField(
         "https://lake.ayon.cloud",
@@ -238,21 +240,30 @@ class LakeFsSettings(BaseSettingsModel):
 
 
 class AyonResolverSettings(BaseSettingsModel):
-    """LakeFs Settings / Download Settings ?"""
+    """AYON USD resolver Settings"""
 
     _layout = "collapsed"
 
     ayon_log_lvl: str = SettingsField(
         "WARN",
-        title="AyonResolver Log Lvl",
+        title="Resolver Log Lvl",
         enum_resolver=log_lvl_enum,
         description="Set verbosity of the AyonUsdResolver logger",
     )
     ayon_file_logger_enabled: str = SettingsField(
         "OFF",
-        title="AyonResolver File Logger Enabled ",
+        title="Resolver File Logger Enabled ",
         enum_resolver=file_logger_enum,
         description="Enable or disable AyonUsdResolver file logger",
+    )
+    file_logger_file_path: str = SettingsField(
+        "",
+        title="Resolver File logger file path",
+        description=(
+            "Allows you to set a custom location where the file logger will "
+            "export to. This can be a relative or absolute path. This is only "
+            "used if `ayon_file_logger_enabled` is enabled."
+        ),
     )
     ayon_logger_logging_keys: str = SettingsField(
         "",
@@ -260,19 +271,10 @@ class AyonResolverSettings(BaseSettingsModel):
         enum_resolver=logger_logging_keys_enum,
         description="List of extra logging options for the AyonCppApi",
     )
-    file_logger_file_path: str = SettingsField(
-        "",
-        title="AyonResolver File logger file path",
-        description=(
-            "Allows you to set a custom location where the file logger will "
-            "export to. This can be a relative or absolute path. This is only "
-            "used if `ayon_file_logger_enabled` is enabled."
-        ),
-    )
 
 
-class UsdSettings(BaseSettingsModel):
-    """LakeFs Settings / Download Settings ?"""
+class UsdLibConfigSettings(BaseSettingsModel):
+    """Settings for USD"""
 
     _layout = "collapsed"
     usd_tf_debug: str = SettingsField(
@@ -283,18 +285,14 @@ class UsdSettings(BaseSettingsModel):
 
 
 class USDSettings(BaseSettingsModel):
-    """USD settings."""
-
-    allow_addon_start: bool = SettingsField(
-        False, title=("I understand and accept that this is an experimental feature")
-    )
 
     lakefs: LakeFsSettings = SettingsField(
-        default_factory=LakeFsSettings, title="LakeFs Config"
+        default_factory=LakeFsSettings, title="LakeFs Binary Distribution"
     )
 
     ayon_usd_resolver: AyonResolverSettings = SettingsField(
-        default_factory=AyonResolverSettings, title="UsdResolver Config"
+        default_factory=AyonResolverSettings, title="AYON USD Resolver Config"
     )
 
-    usd: UsdSettings = SettingsField(default_factory=UsdSettings, title="UsdLib Config")
+    usd: UsdLibConfigSettings = SettingsField(
+        default_factory=UsdLibConfigSettings, title="USD Library Config")


### PR DESCRIPTION
## Changelog Description

Make LakeFS distribution of USD Libs and AYON USD Resolver optional.

## Additional info

+ Remove the experimental checkbox, which is now the "enable" button on the LakeFS distribution section.
+ Cleanup setting titles/docstrings

Fixes #71

![image](https://github.com/user-attachments/assets/760d3299-a564-437f-ab56-9c7871eaba8d)


## Testing notes:

1. Deploy new USD addon package
2. Launcher and applications should run fine without USD libs and resolver.

3. Then, Enable the LakeFS distribution in settings: `ayon+settings://usd/lakefs/enabled`
![image](https://github.com/user-attachments/assets/d41dd197-852e-4e18-9003-bd0432407526)
4. When enabled, it should behave like before and check for latest USD libs and resolvers + download and configure them accordingly for usage in the applications.