### PR TITLE
Allow disabling the pinning file generation in settings

### DIFF
--- a/client/ayon_usd/plugins/publish/extract_skeleton_pinning_json.py
+++ b/client/ayon_usd/plugins/publish/extract_skeleton_pinning_json.py
@@ -35,6 +35,8 @@ class ExtractSkeletonPinningJSON(pyblish.api.InstancePlugin,
     order = pyblish.api.ExtractorOrder + 0.49
     families: ClassVar = ["usd", "usdrender"]
 
+    settings_category: ClassVar = "usd"
+
     @staticmethod
     def _has_usd_representation(representations: list) -> bool:
         return any(

--- a/client/ayon_usd/plugins/publish/integrate_pinning_file.py
+++ b/client/ayon_usd/plugins/publish/integrate_pinning_file.py
@@ -20,6 +20,16 @@ class IntegrateUsdPinningFile(pyblish.api.InstancePlugin):
     label = "Integrate data into USD pinning file"
     families = ["usd", "usdrender"]
 
+    @classmethod
+    def apply_settings(cls, project_settings):
+        # Match enable state of ExtractSkeletonPinningJSON because the plug-ins
+        # should always run in unison.
+        cls.enabled = (
+            project_settings["usd"]["publish"]
+            .get("ExtractSkeletonPinningJSON", {})
+            .get("enabled", True)
+        )
+
     def process(self, instance: pyblish.api.Instance) -> None:
         """Process the plugin."""
 

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -3,6 +3,9 @@ from ayon_server.settings import (
     SettingsField,
 )
 
+class EnabledOnlyModel(BaseSettingsModel):
+    enabled: bool = SettingsField(True)
+
 
 class EnabledBaseModel(BaseSettingsModel):
     _isGroup = True
@@ -20,6 +23,16 @@ class PublishPluginsModel(BaseSettingsModel):
             " the published filepath. "
         )
     )
+    ExtractSkeletonPinningJSON: EnabledOnlyModel = SettingsField(
+        default_factory=EnabledOnlyModel,
+        title="Generate USD Resolver Pinning file on publish",
+        description=(
+            "When enabled, on publishing USD files a pinning file will be "
+            "written along with the published file that pins all dynamic "
+            "entity URIs to the paths in the pinning file. This should be "
+            "disabled when not using the USD resolver."
+        )
+    )
 
 
 DEFAULT_PUBLISH_VALUES = {
@@ -28,4 +41,7 @@ DEFAULT_PUBLISH_VALUES = {
         "optional": False,
         "active": True,
     },
+    "ExtractSkeletonPinningJSON": {
+        "enabled": True
+    }
 }


### PR DESCRIPTION
## Changelog Description

Allow disabling the pinning file generation in settings

## Additional review information

Adds setting `ayon+settings://usd/publish/ExtractSkeletonPinningJSON/enabled`

![image](https://github.com/user-attachments/assets/613f3700-0190-4631-9bce-efb822a85e0a)

With it disabled, it disables the pinning file generation - for if you want to use `ayon-usd` without actually needing any resolver related bits.

## Testing notes:

1. Publishing USD should not trigger any USD pinning file logic when the setting is disabled.