### PR TITLE
Add support for locally pre-installed USD resolver binaries

### DIFF
--- a/client/ayon_usd/hooks/pre_resolver_init.py
+++ b/client/ayon_usd/hooks/pre_resolver_init.py
@@ -2,7 +2,7 @@
 
 import json
 import os
-from ayon_applications import LaunchTypes, PreLaunchHook
+from ayon_applications import PreLaunchHook
 from ayon_usd import config, utils
 from ayon_usd.addon import ADDON_DATA_JSON_PATH
 
@@ -14,10 +14,6 @@ class InitializeAssetResolver(PreLaunchHook):
     """
 
     app_groups = {"maya", "houdini", "unreal"}
-    # TODO Use `farm_render` instead of `farm_publish`
-    # once this issue is resolved
-    # https://github.com/ynput/ayon-applications/issues/2
-    launch_types = {LaunchTypes.local, LaunchTypes.farm_publish}
 
     def execute(self):
         """Pre-launch hook entry method."""
@@ -28,6 +24,23 @@ class InitializeAssetResolver(PreLaunchHook):
                 " disabled.")
             return
 
+        # Check for a locally-configured resolver path first
+        local_path = utils.get_local_resolver_path(
+            project_settings, self.app_name
+        )
+        if local_path:
+            if not os.path.isdir(local_path):
+                self.log.error(
+                    f"Local resolver path does not exist: {local_path}"
+                )
+                return
+            self.log.info(
+                f"Using local resolver path for {self.app_name}: {local_path}"
+            )
+            self._setup_resolver(local_path, project_settings)
+            return
+
+        # Fall through to lakeFS-based resolver download
         resolver_lake_fs_path = utils.get_resolver_to_download(
             project_settings, self.app_name)
         if not resolver_lake_fs_path:
@@ -52,8 +65,20 @@ class InitializeAssetResolver(PreLaunchHook):
             return
 
         # Check for existing local resolver that matches the lakefs timestamp
-        with open(ADDON_DATA_JSON_PATH, "r") as data_json:
-            addon_data_json = json.load(data_json)
+        addon_data_json = {}
+        if os.path.exists(ADDON_DATA_JSON_PATH):
+            try:
+                with open(ADDON_DATA_JSON_PATH, "r") as data_json:
+                    addon_data_json = json.load(data_json)
+            except (json.JSONDecodeError, OSError):
+                self.log.warning(
+                    "Could not read addon data JSON, starting fresh."
+                )
+                addon_data_json = {}
+
+        if not addon_data_json:
+            # Ensure the downloads directory exists
+            os.makedirs(os.path.dirname(ADDON_DATA_JSON_PATH), exist_ok=True)
 
         key = str(self.app_name).replace("/", "_")
         local_resolver_key = f"resolver_data_{key}"

--- a/client/ayon_usd/hooks/pre_resolver_init.py
+++ b/client/ayon_usd/hooks/pre_resolver_init.py
@@ -3,6 +3,7 @@
 import json
 import os
 from ayon_applications import PreLaunchHook
+from ayon_applications.defs import LaunchTypes
 from ayon_usd import config, utils
 from ayon_usd.addon import ADDON_DATA_JSON_PATH
 
@@ -14,6 +15,7 @@ class InitializeAssetResolver(PreLaunchHook):
     """
 
     app_groups = {"maya", "houdini", "unreal"}
+    launch_types = {LaunchTypes.local, LaunchTypes.farm_publish}
 
     def execute(self):
         """Pre-launch hook entry method."""
@@ -23,6 +25,11 @@ class InitializeAssetResolver(PreLaunchHook):
                 "USD Binary distribution for AYON USD Resolver is"
                 " disabled.")
             return
+
+        is_farm = (
+            hasattr(self, "launch_type")
+            and self.launch_type == LaunchTypes.farm_publish
+        )
 
         # Check for a locally-configured resolver path first
         local_path = utils.get_local_resolver_path(
@@ -38,6 +45,15 @@ class InitializeAssetResolver(PreLaunchHook):
                 f"Using local resolver path for {self.app_name}: {local_path}"
             )
             self._setup_resolver(local_path, project_settings)
+            return
+
+        # On the farm, skip the lakeFS download — workers may not have access
+        if is_farm:
+            self.log.warning(
+                "No local resolver path configured for "
+                f"'{self.app_name}' on this platform. "
+                "Skipping lakeFS download on farm worker."
+            )
             return
 
         # Fall through to lakeFS-based resolver download

--- a/client/ayon_usd/plugins/publish/collect_resolver_env_vars.py
+++ b/client/ayon_usd/plugins/publish/collect_resolver_env_vars.py
@@ -1,0 +1,70 @@
+"""Collect USD resolver environment variables for farm job submission.
+
+Emits platform-independent config vars (TF_DEBUG, logger settings) into
+the farm job environment.  Path-based vars (PXR_PLUGINPATH_NAME, PYTHONPATH,
+LD_LIBRARY_PATH) are NOT set here — they are injected by the
+``pre_resolver_init`` hook which runs during ``extractenvironments`` on each
+worker, producing paths correct for that worker's OS.
+"""
+
+import os
+
+import pyblish.api
+
+from ayon_core.pipeline.publish import FARM_JOB_ENV_DATA_KEY
+
+
+class CollectResolverEnvVars(pyblish.api.InstancePlugin):
+    """Collect USD resolver env vars for farm jobs.
+
+    Non-path settings (``TF_DEBUG``, logger config) are read directly
+    from the USD addon settings and added to the farm job environment.
+    """
+
+    order = pyblish.api.CollectorOrder + 0.251
+    label = "Collect USD Resolver Env Vars (Farm Job)"
+
+    families = [
+        # Maya
+        "renderlayer",
+        # Houdini
+        "usdrender",
+        "publish.hou",
+        "remote_publish_on_farm",
+        "redshift_rop",
+        "arnold_rop",
+        "mantra_rop",
+        "karma_rop",
+        "vray_rop",
+    ]
+    targets = ["local"]
+    hosts = ["maya", "houdini"]
+
+    def process(self, instance):
+        if not instance.data.get("farm"):
+            self.log.debug("Not a farm instance, skipping.")
+            return
+
+        settings = instance.context.data["project_settings"]
+        job_env = instance.data.setdefault(FARM_JOB_ENV_DATA_KEY, {})
+
+        # --- Non-path config (from USD addon settings) -------------------
+        usd_settings = settings.get("usd", {})
+        resolver_cfg = usd_settings.get("ayon_usd_resolver", {})
+        config_vars = {
+            "TF_DEBUG": usd_settings.get("usd", {}).get("usd_tf_debug", ""),
+            "AYONLOGGERLOGLVL": resolver_cfg.get("ayon_log_lvl", ""),
+            "AYONLOGGERSFILELOGGING": resolver_cfg.get(
+                "ayon_file_logger_enabled", ""
+            ),
+            "AYONLOGGERSFILEPOS": resolver_cfg.get(
+                "file_logger_file_path", ""
+            ),
+            "AYON_LOGGIN_LOGGIN_KEYS": resolver_cfg.get(
+                "ayon_logger_logging_keys", ""
+            ),
+        }
+        for key, value in config_vars.items():
+            if value:
+                self.log.debug(f"Setting job env (config): {key}: {value}")
+                job_env[key] = str(value)

--- a/client/ayon_usd/utils.py
+++ b/client/ayon_usd/utils.py
@@ -110,6 +110,32 @@ def lakefs_download_and_extract(resolver_lake_fs_path: str,
     return str(extract_zip_item.func_return)
 
 
+def get_local_resolver_path(settings, app_name: str):
+    """Check local_resolver_paths for a matching app + platform entry.
+
+    Args:
+        settings (dict): Project settings.
+        app_name (str): Application name, e.g. "houdini/20-5".
+
+    Returns:
+        str | None: Local filesystem path to the resolver directory,
+            or None if no match found.
+
+    """
+    local_paths = (
+        settings["usd"]["distribution"].get("local_resolver_paths", [])
+    )
+    current_platform = platform.system().lower()
+    for entry in local_paths:
+        if entry["platform"] != current_platform:
+            continue
+        if entry["name"] == app_name or app_name in entry.get(
+            "app_alias_list", []
+        ):
+            return entry["path"]
+    return None
+
+
 def get_resolver_to_download(settings, app_name: str) -> str:
     """
     Gets LakeFs path that can be used with copy element to download

--- a/client/ayon_usd/version.py
+++ b/client/ayon_usd/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring AYON addon 'usd' version."""
-__version__ = "0.1.6+dev"
+__version__ = "0.1.6+ls.0.0.1"

--- a/client/ayon_usd/version.py
+++ b/client/ayon_usd/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring AYON addon 'usd' version."""
-__version__ = "0.1.4+dev"
+__version__ = "0.1.4-ls.0.0.4"

--- a/package.py
+++ b/package.py
@@ -2,7 +2,7 @@
 
 name = "usd"
 title = "USD"
-version = "0.1.4+dev"
+version = "0.1.4-ls.0.0.4"
 client_dir = "ayon_usd"
 
 services = {}

--- a/package.py
+++ b/package.py
@@ -2,7 +2,7 @@
 
 name = "usd"
 title = "USD"
-version = "0.1.6+dev"
+version = "0.1.6+ls.0.0.1"
 client_dir = "ayon_usd"
 
 services = {}

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -98,12 +98,50 @@ class AppPlatformURIModel(BaseSettingsModel):
     )
 
 
+class LocalResolverPathModel(BaseSettingsModel):
+    """Local filesystem path to a pre-installed resolver."""
+
+    _layout = "collapsed"
+    name: str = SettingsField(
+        title="App Name",
+        description="Application name, e.g. houdini/20-5",
+    )
+    app_alias_list: list[str] = SettingsField(
+        title="Application Alias",
+        description="Define a list of App Names that use the same "
+        "resolver as the parent application",
+        default_factory=list,
+    )
+    platform: str = SettingsField(
+        title="Platform",
+        enum_resolver=platform_enum,
+        description="windows / linux / darwin",
+    )
+    path: str = SettingsField(
+        title="Resolver Directory Path",
+        description=(
+            "Local filesystem path to the resolver directory "
+            "(the directory containing `ayonUsdResolver/`)"
+        ),
+    )
+
+
 class BinaryDistributionSettings(BaseSettingsModel):
     """Binary distribution of USD and AYON USD Resolver"""
 
     _layout = "collapsed"
 
     enabled: bool = SettingsField(False)
+
+    local_resolver_paths: list[LocalResolverPathModel] = SettingsField(
+        title="Local Resolver Paths",
+        description=(
+            "Local filesystem paths to pre-installed resolver binaries. "
+            "When a match is found for the current app and platform, "
+            "the resolver is loaded directly without downloading from lakeFS."
+        ),
+        default_factory=list,
+    )
 
     server_uri: str = SettingsField(
         "https://lake.ayon.cloud",


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                                                           
  This PR adds support for locally pre-installed USD resolver binaries and enables farm rendering with the AYON USD resolver.
  
  ### Local resolver paths
  Currently the USD addon only supports downloading the resolver from lakeFS. This works well for artist workstations, but doesn't suit environments where resolvers are already deployed to a shared location (e.g. a network mount) or where lakeFS isn't accessible.

  This adds a new `Local Resolver Paths` setting under Binary Distribution that lets studios configure per-app and platform paths to desired resolver directories. When a match is found, the resolver is loaded directly and no lakeFS download needed. An app alias list is also supported so multiple app variants can share the same resolver.

  ### Farm publishing support
  Farm workers typically don't have access to lakeFS, so resolver setup was failing on the farm. This PR addresses that by:
  - enabling `pre_resolver_init` hook for `farm_publish` launches with fallback that skips lakeFS download when no local path is configured on the worker
  - Add `CollectResolverEnvVars` publish plugin that forwards non-path resolver config (TF_DEBUG, logger settings) into the farm job environment. Path-based env vars (PXR_PLUGINPATH_NAME, PYTHONPATH, LD_LIBRARY_PATH) are intentionally excluded — these are set by the hook at render time for each worker

  ### Other improvements
  - Hardened addon data JSON reading to handle missing or corrupt files instead of crashing
  
  
  Note: This is a massive WIP but I'd like any feedback in the meantime while we are still working on this
