### PR TITLE
Fix the distribution of resolvers on an uninitialised machine

### DIFF
--- a/client/ayon_usd/addon.py
+++ b/client/ayon_usd/addon.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-from datetime import datetime, timezone
 
 from ayon_core import style
 from ayon_core.addon import AYONAddon, IPluginPaths, ITrayAddon
@@ -70,15 +69,7 @@ class USDAddon(AYONAddon, ITrayAddon, IPluginPaths):
             self.log.info("USD Binary distribution is disabled.")
             return
 
-        os.makedirs(DOWNLOAD_DIR, exist_ok=True)
-
-        if not os.path.exists(ADDON_DATA_JSON_PATH):
-            now = datetime.now().astimezone(timezone.utc)
-            with open(ADDON_DATA_JSON_PATH, "w+") as json_file:
-                init_data = {
-                    "ayon_usd_addon_first_init_utc": str(now)
-                }
-                json.dump(init_data, json_file)
+        utils.ensure_addon_data_json()
 
         if not utils.is_usd_lib_download_needed(settings):
             self.log.info("USD Libs already available. Skipping download.")

--- a/client/ayon_usd/addon.py
+++ b/client/ayon_usd/addon.py
@@ -69,7 +69,7 @@ class USDAddon(AYONAddon, ITrayAddon, IPluginPaths):
             self.log.info("USD Binary distribution is disabled.")
             return
 
-        utils.ensure_addon_data_json()
+        utils.create_addon_data_json_file()
 
         if not utils.is_usd_lib_download_needed(settings):
             self.log.info("USD Libs already available. Skipping download.")

--- a/client/ayon_usd/hooks/pre_resolver_init.py
+++ b/client/ayon_usd/hooks/pre_resolver_init.py
@@ -52,7 +52,11 @@ class InitializeAssetResolver(PreLaunchHook):
             return
 
         # Bootstrap addon metadata for launches that happen without tray init.
-        addon_data_json = utils.ensure_addon_data_json()
+        addon_data_json = utils.get_addon_data_json()
+        
+        if not addon_data_json:
+            utils.create_addon_data_json_file()
+            addon_data_json = utils.get_addon_data_json()
 
         key = str(self.app_name).replace("/", "_")
         local_resolver_key = f"resolver_data_{key}"

--- a/client/ayon_usd/hooks/pre_resolver_init.py
+++ b/client/ayon_usd/hooks/pre_resolver_init.py
@@ -51,9 +51,8 @@ class InitializeAssetResolver(PreLaunchHook):
             )
             return
 
-        # Check for existing local resolver that matches the lakefs timestamp
-        with open(ADDON_DATA_JSON_PATH, "r") as data_json:
-            addon_data_json = json.load(data_json)
+        # Bootstrap addon metadata for launches that happen without tray init.
+        addon_data_json = utils.ensure_addon_data_json()
 
         key = str(self.app_name).replace("/", "_")
         local_resolver_key = f"resolver_data_{key}"

--- a/client/ayon_usd/utils.py
+++ b/client/ayon_usd/utils.py
@@ -5,6 +5,7 @@ import os
 import platform
 import pathlib
 import sys
+from datetime import datetime, timezone
 
 from ayon_usd.ayon_bin_client.ayon_bin_distro.work_handler import worker
 from ayon_usd.ayon_bin_client.ayon_bin_distro.util import zip
@@ -13,6 +14,24 @@ from ayon_usd import config
 USD_ADDON_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 DOWNLOAD_DIR = os.path.join(USD_ADDON_ROOT_DIR, "downloads")
 ADDON_DATA_JSON_PATH = os.path.join(DOWNLOAD_DIR, "ayon_usd_addon_info.json")
+
+
+def ensure_addon_data_json() -> dict:
+    """Ensure addon metadata JSON exists and return its content."""
+    os.makedirs(DOWNLOAD_DIR, exist_ok=True)
+
+    if os.path.exists(ADDON_DATA_JSON_PATH):
+        with open(ADDON_DATA_JSON_PATH, "r") as json_file:
+            return json.load(json_file)
+
+    init_data = {
+        "ayon_usd_addon_first_init_utc": str(
+            datetime.now().astimezone(timezone.utc)
+        )
+    }
+    with open(ADDON_DATA_JSON_PATH, "w") as json_file:
+        json.dump(init_data, json_file)
+    return init_data
 
 
 def get_download_dir(create_if_missing=True):
@@ -56,8 +75,7 @@ def is_usd_lib_download_needed(settings: dict) -> bool:
     if not os.path.exists(usd_lib_dir):
         return True
 
-    with open(ADDON_DATA_JSON_PATH, "r") as data_json:
-        addon_data_json = json.load(data_json)
+    addon_data_json = ensure_addon_data_json()
     try:
         usd_lib_lake_fs_time_stamp_local = addon_data_json[
             "usd_lib_lake_fs_time_cest"

--- a/client/ayon_usd/utils.py
+++ b/client/ayon_usd/utils.py
@@ -14,31 +14,35 @@ from ayon_usd import config
 USD_ADDON_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 DOWNLOAD_DIR = os.path.join(USD_ADDON_ROOT_DIR, "downloads")
 ADDON_DATA_JSON_PATH = os.path.join(DOWNLOAD_DIR, "ayon_usd_addon_info.json")
+ADDON_FIRST_INIT_KEY = "ayon_usd_addon_first_init_utc"
 
 
 def get_addon_data_json() -> dict:
     """Get addon data JSON content as dict."""
     if os.path.exists(ADDON_DATA_JSON_PATH):
-        with open(ADDON_DATA_JSON_PATH, "r") as json_file:
-            return json.load(json_file)
+        try:
+            with open(ADDON_DATA_JSON_PATH, "r") as json_file:
+                data = json.load(json_file)
+        except (json.JSONDecodeError, OSError, ValueError):
+            return {}
+        if isinstance(data, dict):
+            return data
     return {}
 
 
 def create_addon_data_json_file():
-    """Create addon data JSON file if it doesn't exist."""
-    if os.path.exists(ADDON_DATA_JSON_PATH):
+    """Ensure addon data JSON file exists and contains init metadata."""
+    os.makedirs(DOWNLOAD_DIR, exist_ok=True)
+    addon_data = get_addon_data_json()
+    if ADDON_FIRST_INIT_KEY in addon_data:
         return
 
-    os.makedirs(DOWNLOAD_DIR, exist_ok=True)
-
-    init_data = {
-        "ayon_usd_addon_first_init_utc": str(
-            datetime.now().astimezone(timezone.utc)
-        )
-    }
+    addon_data[ADDON_FIRST_INIT_KEY] = str(datetime.now().astimezone(
+        timezone.utc
+    ))
 
     with open(ADDON_DATA_JSON_PATH, "w") as json_file:
-        json.dump(init_data, json_file)
+        json.dump(addon_data, json_file)
 
 
 def get_download_dir(create_if_missing=True):

--- a/client/ayon_usd/utils.py
+++ b/client/ayon_usd/utils.py
@@ -16,22 +16,29 @@ DOWNLOAD_DIR = os.path.join(USD_ADDON_ROOT_DIR, "downloads")
 ADDON_DATA_JSON_PATH = os.path.join(DOWNLOAD_DIR, "ayon_usd_addon_info.json")
 
 
-def ensure_addon_data_json() -> dict:
-    """Ensure addon metadata JSON exists and return its content."""
-    os.makedirs(DOWNLOAD_DIR, exist_ok=True)
-
+def get_addon_data_json() -> dict:
+    """Get addon data JSON content as dict."""
     if os.path.exists(ADDON_DATA_JSON_PATH):
         with open(ADDON_DATA_JSON_PATH, "r") as json_file:
             return json.load(json_file)
+    return {}
+
+
+def create_addon_data_json_file():
+    """Create addon data JSON file if it doesn't exist."""
+    if os.path.exists(ADDON_DATA_JSON_PATH):
+        return
+
+    os.makedirs(DOWNLOAD_DIR, exist_ok=True)
 
     init_data = {
         "ayon_usd_addon_first_init_utc": str(
             datetime.now().astimezone(timezone.utc)
         )
     }
+
     with open(ADDON_DATA_JSON_PATH, "w") as json_file:
         json.dump(init_data, json_file)
-    return init_data
 
 
 def get_download_dir(create_if_missing=True):
@@ -75,7 +82,7 @@ def is_usd_lib_download_needed(settings: dict) -> bool:
     if not os.path.exists(usd_lib_dir):
         return True
 
-    addon_data_json = ensure_addon_data_json()
+    addon_data_json = get_addon_data_json()
     try:
         usd_lib_lake_fs_time_stamp_local = addon_data_json[
             "usd_lib_lake_fs_time_cest"


### PR DESCRIPTION
## Changelog Description
This pull request refactors how the addon metadata JSON file is handled to ensure it is always present and initialized correctly. The main improvement is the introduction of a utility function to centralize and simplify the creation and reading of this metadata file.

## Testing notes:
1. start with blank setup (delete downloaded resolvers)
2. launch the DCC
3. test the resolver
4. test it also on a farm
