### PR TITLE
Fix pinning file generation with pinning roots on windows

### DIFF
--- a/client/ayon_usd/standalone/usd/pinning/_pinning_file_generation_funcs.py
+++ b/client/ayon_usd/standalone/usd/pinning/_pinning_file_generation_funcs.py
@@ -23,6 +23,17 @@ def _normalize_path(path):
     return os.path.normpath(path)
 
 
+def _normalize_for_comparison(path: str) -> str:
+    normalized_path = _normalize_path(path).replace("\\", "/")
+    return normalized_path.casefold()
+
+
+def _get_comparison_pattern(path: str) -> str:
+    normalized_path = _normalize_for_comparison(path)
+    escaped_path = re.escape(normalized_path).replace("/", r"[/\\]")
+    return f"(?i:{escaped_path})"
+
+
 def remove_root_from_dependency_info(
     dependency_info: Dict[str, str], root_info: Dict[str, str]
 ) -> Dict[str, str]:
@@ -47,16 +58,21 @@ def remove_root_from_dependency_info(
             f"dependency_info: {dependency_info})"
         )
 
-    replacements = {path: replacer for replacer, path in root_info.items()}
-    pattern = "|".join(f"({re.escape(pat)})" for pat in replacements)
+    replacements = {
+        _normalize_for_comparison(path): replacer
+        for replacer, path in root_info.items()
+    }
+    pattern = "|".join(
+        f"({_get_comparison_pattern(path)})" for path in replacements
+    )
     regx = re.compile(pattern)
 
     # TODO test if there are cases where we have more than one match.group
     def _replace_match(match: re.Match):
-        match_grp_zero = match.group(0)
-        match_replacement = replacements.get(re.escape(match_grp_zero))
+        match_grp_zero = _normalize_for_comparison(match.group(0))
+        match_replacement = replacements.get(match_grp_zero)
         if not match_replacement:
-            return match_grp_zero
+            return match.group(0)
 
         replacement = "{root[" + match_replacement + "]}"
         return replacement

--- a/client/ayon_usd/standalone/usd/pinning/_pinning_file_generation_funcs.py
+++ b/client/ayon_usd/standalone/usd/pinning/_pinning_file_generation_funcs.py
@@ -29,6 +29,13 @@ def _normalize_for_comparison(path: str) -> str:
 
 
 def _get_comparison_pattern(path: str) -> str:
+    """This function creates a case-insensitive regex pattern to handle Windows
+    file paths where the disk drive letter (e.g., C:/ or c:/) can be uppercase 
+    or lowercase.
+
+    Args:
+        path (str): The file path to create a regex pattern for.
+    """
     normalized_path = _normalize_for_comparison(path)
     escaped_path = re.escape(normalized_path).replace("/", r"[/\\]")
     return f"(?i:{escaped_path})"


### PR DESCRIPTION
## Changelog Description
Updated `remove_root_from_dependency_info` to use the new normalization functions for both replacements and regex pattern generation, ensuring consistent matching regardless of path format or case.

## Additional review information
...

## Testing notes:
1. Publish with project roots
2. Check the pinning file
