### PR TITLE
Set AyonUsdResolver as the preferred resolver for Maya

### DIFF
--- a/client/ayon_usd/hooks/pre_maya_launch.py
+++ b/client/ayon_usd/hooks/pre_maya_launch.py
@@ -27,7 +27,7 @@ class SetupAssetResolver(PreLaunchHook):
         """Add the AYON USD Maya startup directory to PYTHONPATH."""
         if not self.data.get("ayon_usd_resolver_initialized"):
             self.log.info(
-                "USD resolver is not initialized; skipping Maya startup setup."
+                "Skipping AYON USD Maya startup initialization because USD resolver is disabled."
             )
             return
 

--- a/client/ayon_usd/hooks/pre_maya_launch.py
+++ b/client/ayon_usd/hooks/pre_maya_launch.py
@@ -1,0 +1,45 @@
+"""Add the AYON USD Maya startup script."""
+
+import os
+
+from ayon_applications import LaunchTypes, PreLaunchHook
+
+
+ADDON_ROOT = os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__))
+)
+
+MAYA_STARTUP_DIR = os.path.join(
+    ADDON_ROOT,
+    "startup",
+    "maya",
+)
+
+
+class SetupAssetResolver(PreLaunchHook):
+    """Add AYON USD initialization to Maya startup."""
+
+    app_groups = {"maya"}
+    launch_types = {LaunchTypes.local}
+
+    def execute(self):
+        env = self.launch_context.env
+
+        current_pythonpath = env.get("PYTHONPATH") or ""
+
+        python_paths = [MAYA_STARTUP_DIR]
+
+        for path in current_pythonpath.split(os.pathsep):
+            if not path:
+                continue
+
+            normalized_path = os.path.normpath(path)
+            if normalized_path not in python_paths:
+                python_paths.append(normalized_path)
+
+        env["PYTHONPATH"] = os.pathsep.join(python_paths)
+
+        self.log.debug(
+            "Added AYON USD Maya startup path: %s",
+            MAYA_STARTUP_DIR,
+        )

--- a/client/ayon_usd/hooks/pre_maya_launch.py
+++ b/client/ayon_usd/hooks/pre_maya_launch.py
@@ -42,30 +42,12 @@ class SetupAssetResolver(PreLaunchHook):
             )
 
         env = self.launch_context.env
-        current_pythonpath = env.get("PYTHONPATH") or ""
-
         paths = [MAYA_STARTUP_DIR]
-        paths.extend(
-            path
-            for path in current_pythonpath.split(os.pathsep)
-            if path
-        )
+        current_pythonpath = env.get("PYTHONPATH")
+        if current_pythonpath:
+            paths.append(current_pythonpath)
 
-        unique_paths = []
-        normalized_paths = set()
-
-        for path in paths:
-            normalized = os.path.normcase(
-                os.path.abspath(os.path.normpath(path))
-            )
-
-            if normalized in normalized_paths:
-                continue
-
-            normalized_paths.add(normalized)
-            unique_paths.append(path)
-
-        env["PYTHONPATH"] = os.pathsep.join(unique_paths)
+        env["PYTHONPATH"] = os.pathsep.join(paths)
 
         self.log.info(
             "Added AYON USD Maya startup directory: %s",

--- a/client/ayon_usd/hooks/pre_maya_launch.py
+++ b/client/ayon_usd/hooks/pre_maya_launch.py
@@ -1,45 +1,73 @@
-"""Add the AYON USD Maya startup script."""
+"""Add the AYON USD startup script to Maya's Python path."""
 
 import os
 
 from ayon_applications import LaunchTypes, PreLaunchHook
 
 
-ADDON_ROOT = os.path.dirname(
-    os.path.dirname(os.path.abspath(__file__))
-)
-
 MAYA_STARTUP_DIR = os.path.join(
-    ADDON_ROOT,
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
     "startup",
     "maya",
 )
 
 
 class SetupAssetResolver(PreLaunchHook):
-    """Add AYON USD initialization to Maya startup."""
+    """Configure the AYON USD startup script for Maya."""
+
+    # Must run after InitializeAssetResolver.
+    order = 20
 
     app_groups = {"maya"}
-    launch_types = {LaunchTypes.local}
+    launch_types = {
+        LaunchTypes.local,
+        LaunchTypes.farm_publish,
+    }
 
     def execute(self):
-        env = self.launch_context.env
+        """Add the AYON USD Maya startup directory to PYTHONPATH."""
+        project_settings = self.data["project_settings"]
+        if not project_settings["usd"]["app_setup"]["maya"]:
+            return
 
+        user_setup_path = os.path.join(
+            MAYA_STARTUP_DIR,
+            "userSetup.py",
+        )
+
+        if not os.path.isfile(user_setup_path):
+            raise RuntimeError(
+                "AYON USD Maya userSetup.py was not found: "
+                f"{user_setup_path}"
+            )
+
+        env = self.launch_context.env
         current_pythonpath = env.get("PYTHONPATH") or ""
 
-        python_paths = [MAYA_STARTUP_DIR]
+        paths = [MAYA_STARTUP_DIR]
+        paths.extend(
+            path
+            for path in current_pythonpath.split(os.pathsep)
+            if path
+        )
 
-        for path in current_pythonpath.split(os.pathsep):
-            if not path:
+        unique_paths = []
+        normalized_paths = set()
+
+        for path in paths:
+            normalized = os.path.normcase(
+                os.path.abspath(os.path.normpath(path))
+            )
+
+            if normalized in normalized_paths:
                 continue
 
-            normalized_path = os.path.normpath(path)
-            if normalized_path not in python_paths:
-                python_paths.append(normalized_path)
+            normalized_paths.add(normalized)
+            unique_paths.append(path)
 
-        env["PYTHONPATH"] = os.pathsep.join(python_paths)
+        env["PYTHONPATH"] = os.pathsep.join(unique_paths)
 
-        self.log.debug(
-            "Added AYON USD Maya startup path: %s",
+        self.log.info(
+            "Added AYON USD Maya startup directory: %s",
             MAYA_STARTUP_DIR,
         )

--- a/client/ayon_usd/hooks/pre_maya_launch.py
+++ b/client/ayon_usd/hooks/pre_maya_launch.py
@@ -21,13 +21,14 @@ class SetupAssetResolver(PreLaunchHook):
     app_groups = {"maya"}
     launch_types = {
         LaunchTypes.local,
-        LaunchTypes.farm_publish,
     }
 
     def execute(self):
         """Add the AYON USD Maya startup directory to PYTHONPATH."""
-        project_settings = self.data["project_settings"]
-        if not project_settings["usd"]["app_setup"]["maya"]:
+        if not self.data.get("ayon_usd_resolver_initialized"):
+            self.log.info(
+                "USD resolver is not initialized; skipping Maya startup setup."
+            )
             return
 
         user_setup_path = os.path.join(

--- a/client/ayon_usd/hooks/pre_maya_launch.py
+++ b/client/ayon_usd/hooks/pre_maya_launch.py
@@ -26,7 +26,7 @@ class SetupAssetResolver(PreLaunchHook):
     def execute(self):
         """Add the AYON USD Maya startup directory to PYTHONPATH."""
         if not self.data.get("ayon_usd_resolver_initialized"):
-            self.log.info(
+            self.log.debug(
                 "Skipping AYON USD Maya startup initialization because USD resolver is disabled."
             )
             return
@@ -43,10 +43,10 @@ class SetupAssetResolver(PreLaunchHook):
             )
 
         env = self.launch_context.env
-        paths = [MAYA_STARTUP_DIR]
-        current_pythonpath = env.get("PYTHONPATH")
-        if current_pythonpath:
-            paths.append(current_pythonpath)
+        current_pythonpath = env.get("PYTHONPATH", "")
+        paths = current_pythonpath.split(os.pathsep) if current_pythonpath else []
+        if MAYA_STARTUP_DIR not in paths:
+            paths.append(MAYA_STARTUP_DIR)
 
         env["PYTHONPATH"] = os.pathsep.join(paths)
 

--- a/client/ayon_usd/hooks/pre_resolver_init.py
+++ b/client/ayon_usd/hooks/pre_resolver_init.py
@@ -24,6 +24,7 @@ class InitializeAssetResolver(PreLaunchHook):
 
     def execute(self):
         """Pre-launch hook entry method."""
+        self.data["ayon_usd_resolver_initialized"] = False
         project_settings = self.data["project_settings"]
         local_resolver = None
 
@@ -133,3 +134,4 @@ class InitializeAssetResolver(PreLaunchHook):
             local_resolver, settings, env=self.launch_context.env
         )
         self.launch_context.env.update(updated_env)
+        self.data["ayon_usd_resolver_initialized"] = True

--- a/client/ayon_usd/hooks/pre_resolver_init.py
+++ b/client/ayon_usd/hooks/pre_resolver_init.py
@@ -14,6 +14,7 @@ class InitializeAssetResolver(PreLaunchHook):
 
     Asset resolver is used to resolve assets in the application.
     """
+    order = 10
 
     app_groups = {"maya", "houdini", "unreal"}
     # TODO Use `farm_render` instead of `farm_publish`

--- a/client/ayon_usd/hooks/pre_resolver_init.py
+++ b/client/ayon_usd/hooks/pre_resolver_init.py
@@ -114,7 +114,14 @@ class InitializeAssetResolver(PreLaunchHook):
     def _handle_local_distribution(self, settings) -> Optional[str]:
         resolver_path = utils.get_local_resolver_path(settings, self.app_name)
 
-        if not resolver_path or not os.path.isdir(resolver_path):
+        if not resolver_path:
+            self.log.warning(
+                "No local resolver path could be found for application: "
+                f"{self.app_name}"
+            )
+            return None
+        
+        if not os.path.isdir(resolver_path):
             self.log.error(f"Invalid local resolver path: {resolver_path}")
             return None
 

--- a/client/ayon_usd/startup/maya/userSetup.py
+++ b/client/ayon_usd/startup/maya/userSetup.py
@@ -4,4 +4,4 @@ from pxr import Ar
 
 Ar.SetPreferredResolver("AyonUsdResolver")
 
-print("Preffered USD asset resolver set to `AyonUsdResolver`")
+print("Preferred USD asset resolver set to 'AyonUsdResolver'")

--- a/client/ayon_usd/startup/maya/userSetup.py
+++ b/client/ayon_usd/startup/maya/userSetup.py
@@ -1,0 +1,7 @@
+"""Initialize AYON USD before the regular AYON Maya startup."""
+
+from pxr import Ar
+
+Ar.SetPreferredResolver("AyonUsdResolver")
+
+print("Preffered USD asset resolver set to `AyonUsdResolver`")

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -407,7 +407,7 @@ class USDSettings(BaseSettingsModel):
     )
 
     app_setup: AppPreferefResolverSetup = SettingsField(
-        default_factory=AppPreferefResolverSetup, title="Set AyonUsdResolver as prefered"
+        default_factory=AppPreferefResolverSetup, title="Set AyonUsdResolver as preferred"
     )
 
     ayon_usd_resolver: AyonResolverSettings = SettingsField(

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -349,12 +349,6 @@ class BinaryDistributionSettings(BaseSettingsModel):
     )
 
 
-class AppPreferefResolverSetup(BaseSettingsModel):
-    maya: bool = SettingsField(
-        title="Maya",
-        default=False,
-    )
-
 class AyonResolverSettings(BaseSettingsModel):
     """AYON USD resolver Settings"""
 
@@ -404,10 +398,6 @@ class USDSettings(BaseSettingsModel):
 
     distribution: BinaryDistributionSettings = SettingsField(
         default_factory=BinaryDistributionSettings, title="Binary Distribution"
-    )
-
-    app_setup: AppPreferefResolverSetup = SettingsField(
-        default_factory=AppPreferefResolverSetup, title="Set AyonUsdResolver as preferred"
     )
 
     ayon_usd_resolver: AyonResolverSettings = SettingsField(

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -349,6 +349,12 @@ class BinaryDistributionSettings(BaseSettingsModel):
     )
 
 
+class AppPreferefResolverSetup(BaseSettingsModel):
+    maya: bool = SettingsField(
+        title="Maya",
+        default=False,
+    )
+
 class AyonResolverSettings(BaseSettingsModel):
     """AYON USD resolver Settings"""
 
@@ -398,6 +404,10 @@ class USDSettings(BaseSettingsModel):
 
     distribution: BinaryDistributionSettings = SettingsField(
         default_factory=BinaryDistributionSettings, title="Binary Distribution"
+    )
+
+    app_setup: AppPreferefResolverSetup = SettingsField(
+        default_factory=AppPreferefResolverSetup, title="Set AyonUsdResolver as prefered"
     )
 
     ayon_usd_resolver: AyonResolverSettings = SettingsField(


### PR DESCRIPTION
## Changelog Description
This PR adds a prelaunch hook that is responsible for setting the `AyonUsdResolver` as the preferred one. This functionality can be enabled/disabled in settings. 

The reason of this is to avoid issues with loading only the default Autodesk resolver, which is technically disabling the AYON one.

## Testing notes:
1. launch Maya with `usd` addon, test if the resolver was loaded and run this code from the issue:
```
from pxr import Ar
import time
from usdAssetResolver import AyonUsdResolver

Ar.SetPreferredResolver("AyonUsdResolver")
resolver = Ar.GetResolver()
context = AyonUsdResolver.ResolverContext()
``` 

2. launch app without defined resolver path in settings -> see the logs
